### PR TITLE
Change contact information for consistency

### DIFF
--- a/coc.md
+++ b/coc.md
@@ -58,7 +58,7 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at info@opensciencemooc.eu. All
+reported by contacting [chris@libscie.org](mailto:chris@libscie.org) or [bianca.kramer@gmail.com](mailto:bianca.kramer@gmail.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
This commit makes the contact points consistent with all other CoC mentions throughout the module repository's. It is rather urgent to merge this .

The only reason I did not commit to master is because I was unsure whether the page needs to be manually rebuild or it does so automatically (could we add that to the `README.md` for clarity?).